### PR TITLE
(Nash) (WIP) Beam Break handoff + separate rev and shot commands

### DIFF
--- a/competition/2024 KwarQs competition code/src/main/java/frc/robot/RobotContainer.java
+++ b/competition/2024 KwarQs competition code/src/main/java/frc/robot/RobotContainer.java
@@ -239,17 +239,26 @@ public class RobotContainer {
 
     new JoystickButton(driverXbox, XboxController.Button.kA.value).whileTrue(intakeCommands.intakeDown());
     new JoystickButton(driverXbox, XboxController.Button.kX.value).whileTrue(intakeCommands.intakeUp());
-    new JoystickButton(driverXbox, XboxController.Button.kRightBumper.value)
-        .whileTrue(shooterAngleCommands.moveShooterDown());
+    new JoystickButton(driverXbox, XboxController.Button.kRightBumper.value).whileTrue(
+        Commands.parallel(
+            ShooterCommands.revSpeedFromDAS(),
+            shooterAngle.setShooterAngleFromDAS())
+    );
+    
     new JoystickButton(driverXbox, XboxController.Button.kLeftBumper.value)
-        .whileTrue(shooterAngleCommands.moveShooterUp());
+        .whileTrue(shooterCommands.rev());
+    
 
     // new Trigger(() -> driverXbox.getRightTriggerAxis() >
     // .5).whileTrue(shooterCommands.shooterCommand());
 
-    new Trigger(() -> driverXbox.getRightTriggerAxis() > .5).whileTrue(shooterCommands.shootFromDAS())
+    new Trigger(() -> driverXbox.getRightTriggerAxis() > .5 && !driverXbox.getRightBumper()).whileTrue(shooterCommands.shootFromDAS())
         .onFalse(shooterAngleCommands.shooterAngleCommand());
-    new Trigger(() -> driverXbox.getLeftTriggerAxis() > .5).whileTrue(shooterCommands.revAndShoot());
+    new Trigger(() -> driverXbox.getLeftTriggerAxis() > .5 && !driverXbox.getLeftBumper()).whileTrue(shooterCommands.revAndShoot());
+    new Trigger(() -> driverXbox.getLeftTriggerAxis() > .5 && driverXbox.getLeftBumper()).whileTrue(shooterCommands.shoot());
+    new Trigger(() -> driverXbox.getRightTriggerAxis() > .5 && driverXbox.getRightBumper()).whileTrue(shooterCommands.shoot());
+    new Trigger(() -> driverXbox.getRightTriggerAxis() <= .5 && !driverXbox.getRightBumper()).onTrue(shooterAngleCommands.shooterAngleCommand());
+    // TODO: new Trigger for auto-align if we are still holding the right bumper but we are no longer trying to drive (driver analog stick axes all very small)
     new Trigger(() -> operator.getRightTriggerAxis() > .5).whileTrue(shooterCommands.moveFeedAmpCommand())
         .onFalse(shooterCommands.moveFeedAmpCommandEnd());
     new Trigger(() -> operator.getLeftTriggerAxis() > .5).whileTrue(shooterCommands.moveFeedAmpOppCommand());

--- a/competition/2024 KwarQs competition code/src/main/java/frc/robot/subsystems/shooter/ShooterCommands.java
+++ b/competition/2024 KwarQs competition code/src/main/java/frc/robot/subsystems/shooter/ShooterCommands.java
@@ -124,6 +124,15 @@ public class ShooterCommands {
         return command;
     }
 
+    public Command handOffWithBeamBreakCommand() {
+        var command = Commands.sequence(
+            /* change from "slow" to "handoff" */
+            Commands.parallel(moveFeedSlowCommand(), intake.intakeIntake(.7))
+                    .until(() -> shooter.isBeamBroken()),
+            Commands.runOnce(() -> shooter.everythingOffPlease())); 
+            return command;
+    }
+
     public Command flopAmpCommand() {
 
         var command = Commands.sequence(
@@ -145,7 +154,7 @@ public class ShooterCommands {
         return command;
     }
 
-    private Command revSpeedFromDAS() {
+    public Command revSpeedFromDAS() {
         return Commands.run(() -> {
             double distance = drivebase.getDistanceToSpeaker();
             DAS.MotorSettings as = RobotContainer.das.calculateAS(distance);


### PR DESCRIPTION
Add a command for handing off until new beam is broken (pending sensor), for intaking during rev (mainly for auto)

Add new control bindings for pressing the bumper to rev ahead of time, then pressing the trigger while still holding the bumper to complete the shot (trusting for now that the rev is done by assuming Ben has held ithe bumper for long enough). Using the trigger without the bumper should still do the shot as normal. For the right hand (vision-assisted), the bumper will rev and tilt, but will not auto-align. There is a comment explaining the trigger we still want to add for doing the auto-align while reving (once the drive is not being otherwise moved).